### PR TITLE
Integrate new depsolver with semver support

### DIFF
--- a/config/software/chef-pedant.rb
+++ b/config/software/chef-pedant.rb
@@ -17,7 +17,7 @@
 
 name "chef-pedant"
 
-version "1.0.3"
+version "1.0.6"
 
 dependency "ruby"
 dependency "bundler"

--- a/config/software/erchef.rb
+++ b/config/software/erchef.rb
@@ -16,7 +16,7 @@
 #
 
 name "erchef"
-version "1.2.6"
+version "sf/eric-semver"
 
 dependency "erlang"
 dependency "rsync"


### PR DESCRIPTION
This set of PRs integrates an update to depsolver that includes
support for semver versions at the depsolver layer. It does NOT add
support at the chef level, but everything is working with the API
change in depsolver.
