### PR TITLE
CHEF-3838 : RabbitMQ does not start on Oracle or Amazon Linux

### DIFF
--- a/files/chef-server-cookbooks/runit/recipes/default.rb
+++ b/files/chef-server-cookbooks/runit/recipes/default.rb
@@ -27,6 +27,8 @@ when "redhat","centos","rhel","scientific"
   else
     include_recipe "runit::sysvinit"
   end
+when "amazon"
+  include_recipe "runit::upstart"
 else
   include_recipe "runit::sysvinit"
 end


### PR DESCRIPTION
This is Rob Skaggs workaround to set amazon linux to use upstart instead of sysvinit. I've tested it and it works.

I looked at COOK-2545 but wasn't able to easily get it working as a fix. It looks like using the newer runit cookbook with the fix mentioned in COOK-2545 would require including at least build-essential and yum cookbooks in the omnibus-chef-server which seems like the wrong way to go. If that direction is preferred feel free to close/ignore this PR
