### PR TITLE
Make it possible to actually use an alternate port for embedded Postgres

### DIFF
--- a/files/chef-server-cookbooks/chef-server/recipes/postgresql.rb
+++ b/files/chef-server-cookbooks/chef-server/recipes/postgresql.rb
@@ -134,11 +134,13 @@ end
 # Create the database, migrate it, and create the users we need, and grant them
 # privileges.
 ###
-database_exists = "/opt/chef-server/embedded/bin/chpst -u #{node['chef_server']['postgresql']['username']} /opt/chef-server/embedded/bin/psql -d 'template1' -c 'select datname from pg_database' -x|grep opscode_chef"
-user_exists     = "/opt/chef-server/embedded/bin/chpst -u #{node['chef_server']['postgresql']['username']} /opt/chef-server/embedded/bin/psql -d 'template1' -c 'select usename from pg_user' -x|grep #{node['chef_server']['postgresql']['sql_user']}"
-ro_user_exists  = "/opt/chef-server/embedded/bin/chpst -u #{node['chef_server']['postgresql']['username']} /opt/chef-server/embedded/bin/psql -d 'template1' -c 'select usename from pg_user' -x|grep #{node['chef_server']['postgresql']['sql_ro_user']}"
+psql_command_with_port = "/opt/chef-server/embedded/bin/psql -p #{node['chef_server']['postgresql']['port']}"
 
-execute "/opt/chef-server/embedded/bin/createdb -T template0 -E UTF-8 opscode_chef" do
+database_exists = "/opt/chef-server/embedded/bin/chpst -u #{node['chef_server']['postgresql']['username']} #{psql_command_with_port} -d 'template1' -c 'select datname from pg_database' -x|grep opscode_chef"
+user_exists     = "/opt/chef-server/embedded/bin/chpst -u #{node['chef_server']['postgresql']['username']} #{psql_command_with_port} -d 'template1' -c 'select usename from pg_user' -x|grep #{node['chef_server']['postgresql']['sql_user']}"
+ro_user_exists  = "/opt/chef-server/embedded/bin/chpst -u #{node['chef_server']['postgresql']['username']} #{psql_command_with_port} -d 'template1' -c 'select usename from pg_user' -x|grep #{node['chef_server']['postgresql']['sql_ro_user']}"
+
+execute "/opt/chef-server/embedded/bin/createdb -T template0 -E UTF-8 opscode_chef -p #{node['chef_server']['postgresql']['port']}" do
   user node['chef_server']['postgresql']['username']
   not_if database_exists
   retries 30
@@ -146,13 +148,13 @@ execute "/opt/chef-server/embedded/bin/createdb -T template0 -E UTF-8 opscode_ch
 end
 
 execute "migrate_database" do
-  command "/opt/chef-server/embedded/bin/psql opscode_chef < priv/pgsql_schema.sql"
+  command "#{psql_command_with_port} opscode_chef < priv/pgsql_schema.sql"
   cwd chef_db_dir
   user node['chef_server']['postgresql']['username']
   action :nothing
 end
 
-execute "/opt/chef-server/embedded/bin/psql -d 'opscode_chef' -c \"CREATE USER #{node['chef_server']['postgresql']['sql_user']} WITH SUPERUSER ENCRYPTED PASSWORD '#{node['chef_server']['postgresql']['sql_password']}'\"" do
+execute "#{psql_command_with_port} -d 'opscode_chef' -c \"CREATE USER #{node['chef_server']['postgresql']['sql_user']} WITH SUPERUSER ENCRYPTED PASSWORD '#{node['chef_server']['postgresql']['sql_password']}'\"" do
   cwd chef_db_dir
   user node['chef_server']['postgresql']['username']
   notifies :run, "execute[grant opscode_chef privileges]", :immediately
@@ -160,12 +162,12 @@ execute "/opt/chef-server/embedded/bin/psql -d 'opscode_chef' -c \"CREATE USER #
 end
 
 execute "grant opscode_chef privileges" do
-  command "/opt/chef-server/embedded/bin/psql -d 'opscode_chef' -c \"GRANT ALL PRIVILEGES ON DATABASE opscode_chef TO #{node['chef_server']['postgresql']['sql_user']}\""
+  command "#{psql_command_with_port} -d 'opscode_chef' -c \"GRANT ALL PRIVILEGES ON DATABASE opscode_chef TO #{node['chef_server']['postgresql']['sql_user']}\""
   user node['chef_server']['postgresql']['username']
   action :nothing
 end
 
-execute "/opt/chef-server/embedded/bin/psql -d 'opscode_chef' -c \"CREATE USER #{node['chef_server']['postgresql']['sql_ro_user']} WITH SUPERUSER ENCRYPTED PASSWORD '#{node['chef_server']['postgresql']['sql_ro_password']}'\"" do
+execute "#{psql_command_with_port} -d 'opscode_chef' -c \"CREATE USER #{node['chef_server']['postgresql']['sql_ro_user']} WITH SUPERUSER ENCRYPTED PASSWORD '#{node['chef_server']['postgresql']['sql_ro_password']}'\"" do
   cwd chef_db_dir
   user node['chef_server']['postgresql']['username']
   notifies :run, "execute[grant opscode_chef_ro privileges]", :immediately
@@ -173,7 +175,7 @@ execute "/opt/chef-server/embedded/bin/psql -d 'opscode_chef' -c \"CREATE USER #
 end
 
 execute "grant opscode_chef_ro privileges" do
-  command "/opt/chef-server/embedded/bin/psql -d 'opscode_chef' -c \"GRANT ALL PRIVILEGES ON DATABASE opscode_chef TO #{node['chef_server']['postgresql']['sql_ro_user']}\""
+  command "#{psql_command_with_port} -d 'opscode_chef' -c \"GRANT ALL PRIVILEGES ON DATABASE opscode_chef TO #{node['chef_server']['postgresql']['sql_ro_user']}\""
   user node['chef_server']['postgresql']['username']
   action :nothing
 end


### PR DESCRIPTION
Overriding postgresql['port'] in chef-server.rb doesn't actually work. This is handy when installing omnibus on a machine w/ an existing postgres installation. This fixes it such that an alternate port specification works.
