### PR TITLE
Fix ability to specify alternate log dirs for all services.

### DIFF
--- a/files/chef-server-cookbooks/chef-server/libraries/chef_server.rb
+++ b/files/chef-server-cookbooks/chef-server/libraries/chef_server.rb
@@ -34,6 +34,8 @@ module ChefServer
   bookshelf Mash.new
   bootstrap Mash.new
   nginx Mash.new
+  chef_pedant Mash.new
+  estatsd Mash.new
   api_fqdn nil
   node nil
   notification_email nil
@@ -99,6 +101,8 @@ module ChefServer
         "lb",
         "postgresql",
         "nginx",
+        "chef_pedant",
+        "estatsd",
         "bookshelf",
         "bootstrap"
       ].each do |key|

--- a/files/chef-server-cookbooks/chef-server/recipes/rabbitmq.rb
+++ b/files/chef-server-cookbooks/chef-server/recipes/rabbitmq.rb
@@ -77,7 +77,7 @@ if node['chef_server']['bootstrap']['enable']
 		retries 20
 	end
 
-  execute "/opt/chef-server/embedded/bin/chpst -u #{node["chef_server"]["user"]["username"]} -U #{node["chef_server"]["user"]["username"]} /opt/chef-server/embedded/bin/rabbitmqctl wait /var/opt/chef-server/rabbitmq/db/rabbit@localhost.pid" do
+  execute "/opt/chef-server/embedded/bin/chpst -u #{node["chef_server"]["user"]["username"]} -U #{node["chef_server"]["user"]["username"]} /opt/chef-server/embedded/bin/rabbitmqctl wait #{rabbitmq_data_dir}/rabbit@localhost.pid" do
     retries 10
   end
 

--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
@@ -1,6 +1,6 @@
 user <%= node['chef_server']['user']['username'] %> <%= node['chef_server']['user']['username']%>;
 worker_processes <%= @worker_processes %>;
-error_log /var/log/chef-server/nginx/error.log<%= node['chef_server']['lb']['debug'] ? " debug" : "" %>;
+error_log <%= node['chef_server']['nginx']['log_directory'] %>/error.log<%= node['chef_server']['lb']['debug'] ? " debug" : "" %>;
 
 daemon off;
 
@@ -52,7 +52,7 @@ http {
   server {
     listen <%= @non_ssl_port %>;
     server_name <%= @server_name %>;
-    access_log /var/log/chef-server/nginx/rewrite-port-<%= @non_ssl_port %>.log;
+    access_log <%= node['chef_server']['nginx']['log_directory'] %>/rewrite-port-<%= @non_ssl_port %>.log;
     rewrite ^(.*) https://$server_name:<%= @ssl_port %>$1 permanent;
   }
   <%- end -%>

--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx_chef_api_lb.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx_chef_api_lb.conf.erb
@@ -1,7 +1,7 @@
 server {
   listen <%= @server_port %>;
   server_name <%= @server_name %>;
-  access_log /var/log/chef-server/nginx/access.log opscode;
+  access_log <%= node['chef_server']['nginx']['log_directory'] %>/access.log opscode;
 
   <% if @server_proto == "https" -%>
   ssl on;


### PR DESCRIPTION
- Allow chef_pedant and estatsd to actually be configured in chef_server.rb (as documented), such that their log directories can be overridden.
- Fix hardcoded occurrences of log directories to make log directory changes possible.
