### PR TITLE
OpenResty support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: a1f25d7ab6930826822323b373b8298bff02fed1
+  revision: c978c3ebec976b4c315eb52ffda4a799d7e2cd31
   branch: master
   specs:
     omnibus-software (0.0.1)

--- a/config/projects/chef-server-core.rb
+++ b/config/projects/chef-server-core.rb
@@ -32,7 +32,7 @@ dependency "chef-gem" # for embedded chef-solo
 dependency "chef-server-cookbooks" # used by chef-server-ctl reconfigure
 dependency "chef-server-scripts" # assorted scripts used by installed instance
 dependency "chef-server-ctl" # additional project-specific chef-server-ctl subcommands
-dependency "nginx" # load balacning
+dependency "openresty" # load balacning
 dependency "runit"
 
 # the backend

--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -32,7 +32,7 @@ dependency "chef-gem" # for embedded chef-solo
 dependency "chef-server-cookbooks" # used by chef-server-ctl reconfigure
 dependency "chef-server-scripts" # assorted scripts used by installed instance
 dependency "chef-server-ctl" # additional project-specific chef-server-ctl subcommands
-dependency "nginx" # load balacning
+dependency "openresty" # load balacning
 dependency "runit"
 dependency "unicorn" # serves up Rack apps (chef-server-webui)
 


### PR DESCRIPTION
This will ensure all flavors of Chef Server (OSC, OPC, OHC) are using the same bundle of Nginx for load balancing. It also allows OSC to take advantage of the `HttpLuaModule` for more complicated routing logic.