### PR TITLE
fix port 80 redirect

### DIFF
--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
@@ -52,7 +52,7 @@ http {
   server {
     listen <%= @non_ssl_port %>;
     access_log /var/log/chef-server/nginx/rewrite-port-<%= @non_ssl_port %>.log;
-    return 301 https://$host$request_uri;
+    return 301 https://$host:<%= @ssl_port %>$request_uri;
   }
   <%- end -%>
   <%-  end -%>


### PR DESCRIPTION
1. redirect to whatever host we were called with no matter what api_fqdn
   is set to via using $host.
2. avoid 'taxing' rewrites (http://wiki.nginx.org/Pitfalls#Taxing_Rewrites)
