### PR TITLE
platform_family-ization

### DIFF
--- a/files/chef-server-cookbooks/runit/recipes/default.rb
+++ b/files/chef-server-cookbooks/runit/recipes/default.rb
@@ -17,16 +17,24 @@
 # limitations under the License.
 #
 
-# TODO: This needs RHEL support
-case node["platform"]
-when "ubuntu"
+case node["platform_family"]
+when "debian"
   include_recipe "runit::upstart"
-when "redhat","centos","rhel","scientific"
-  if node['platform_version'] =~ /^6/
+when "rhel"
+  case node["platform"]
+  when "amazon", "xenserver"
+    # TODO: platform_version check for old distro without upstart
     include_recipe "runit::upstart"
   else
-    include_recipe "runit::sysvinit"
+    if node['platform_version'] =~ /^5/
+      include_recipe "runit::sysvinit"
+    else # >= 6.0
+      include_recipe "runit::upstart"
+    end
   end
+when "fedora"
+  # TODO: platform_version check for old distro without upstart
+  include_recipe "runit::upstart"
 else
   include_recipe "runit::sysvinit"
 end


### PR DESCRIPTION
handles RHEL5/RHEL6 and should handle RHEL7 correctly (as long as it is RHEL6-like) and uses platform_family to catch all current and future RHEL variants correctly.  it even handles current versions of xenserver, fedora and amazon, along with all the debian flavors (chef-server on raspbian...).  it does not handle old xenserver/fedora/amazon version that are RHEL5-like.
