### PR TITLE
[CHEF-4188] Change embedded runit inittab id

### DIFF
--- a/files/chef-server-cookbooks/runit/recipes/sysvinit.rb
+++ b/files/chef-server-cookbooks/runit/recipes/sysvinit.rb
@@ -18,7 +18,7 @@
 #
 
 # We assume you are sysvinit
-svdir_line = 'SV:123456:respawn:/opt/chef-server/embedded/bin/runsvdir-start'
+svdir_line = 'CS:123456:respawn:/opt/chef-server/embedded/bin/runsvdir-start'
 execute "echo '#{svdir_line}' >> /etc/inittab" do
   not_if "grep '#{svdir_line}' /etc/inittab"
   notifies :run, "execute[init q]", :immediately


### PR DESCRIPTION
In order to not conflict with user installed runit packages, this change
uses CS (abbreviation for chef-server or chef sv) as inittab id.
