### PR TITLE
Delete *.siz files on Erchef reconfiguration

### DIFF
--- a/files/chef-server-cookbooks/chef-server/recipes/erchef.rb
+++ b/files/chef-server-cookbooks/chef-server/recipes/erchef.rb
@@ -51,7 +51,25 @@ template erchef_config do
   source "erchef.config.erb"
   mode "644"
   variables(node['chef_server']['erchef'].to_hash)
+  notifies :run, 'execute[remove_erchef_siz_files]', :immediately
   notifies :restart, 'service[erchef]' if OmnibusHelper.should_notify?("erchef")
+end
+
+# Erchef still ultimately uses disk_log [1] for request logging, and if
+# you change the log file sizing in the configuration **without also
+# issuing a call to disk_log:change_size/2, Erchef won't start.
+#
+# Since we currently don't perform live upgrades, we can fake this by
+# removing the *.siz files, which is where disk_log looks to determine
+# what size the log files should be in the first place.  If they're
+# not there, then we just use whatever size is listed in the
+# configuration.
+#
+# [1]: http://erlang.org/doc/man/disk_log.html
+execute "remove_erchef_siz_files" do
+  command "rm -f *.siz"
+  cwd erchef_log_dir
+  action :nothing
 end
 
 link "/opt/chef-server/embedded/service/erchef/etc/app.config" do


### PR DESCRIPTION
This allows us to change log file size configuration and still have
Erchef boot up; see code comments for more details.

cc: @seth 

UPDATE: Passed CI: http://andra.ci.opscode.us/job/chef-server-trigger-ad-hoc/107/downstreambuildview/?
