### PR TITLE
Fix bootstrap flag for nginx service

### DIFF
--- a/files/chef-server-cookbooks/chef-server/recipes/nginx.rb
+++ b/files/chef-server-cookbooks/chef-server/recipes/nginx.rb
@@ -146,7 +146,7 @@ runit_service "nginx" do
   }.merge(params))
 end
 
-if node['chef_server']['nginx']['bootstrap']
+if node['chef_server']['bootstrap']['enable']
 	execute "/opt/chef-server/bin/chef-server-ctl start nginx" do
 		retries 20
 	end


### PR DESCRIPTION
All other chef-server components use node['chef_server']['bootstrap']['enable'], so nginx should also use it.
