### PR TITLE
Make nginx listen on ipv6 interfaces

### DIFF
--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
@@ -51,6 +51,7 @@ http {
 
   server {
     listen <%= @non_ssl_port %>;
+    listen [::]:<%= @non_ssl_port %>;
     access_log /var/log/chef-server/nginx/rewrite-port-<%= @non_ssl_port %>.log;
     return 301 https://$host:<%= @ssl_port %>$request_uri;
   }

--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx_chef_api_lb.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx_chef_api_lb.conf.erb
@@ -1,5 +1,6 @@
 server {
   listen <%= @server_port %>;
+  listen [::]:<%= @server_port %>;
   server_name <%= @server_name %>;
   access_log /var/log/chef-server/nginx/access.log opscode;
 


### PR DESCRIPTION
This is needed for IPv6-only environments but shouldn't hurt dual-stack or
IPv4-only environments.  It's in the same spirit as the IPv4 variant, _just listening on any interface_.
