### PR TITLE
Update omnibus-software with openssl security fix:

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 1fa82ad5e674b1700b0a28a93fa2801ff6db9290
+  revision: f37700aaa3752d98d2e3d38cb6704bd850efc8ba
   branch: master
   specs:
     omnibus-software (0.0.1)


### PR DESCRIPTION
Update to OpenSSL 1.0.1f to fix security vulnerability:
- [CHEF-4939], [CVE-2013-4353]:  NPE caused by carefully crafted invalid TLS handshake.

Tested:  http://andra.ci.opscode.us/job/chef-server-trigger-ad-hoc/134/downstreambuildview/

@schisamo 
