### PR TITLE
CHEF-2245: Remove jetty request log

### DIFF
--- a/files/chef-server-cookbooks/chef-server/templates/default/jetty.xml.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/jetty.xml.erb
@@ -108,9 +108,6 @@
            <Item>
              <New id="DefaultHandler" class="org.mortbay.jetty.handler.DefaultHandler"/>
            </Item>
-           <Item>
-             <New id="RequestLog" class="org.mortbay.jetty.handler.RequestLogHandler"/>
-           </Item>
          </Array>
         </Set>
       </New>
@@ -182,25 +179,6 @@
 	-->
       </Array>
     </Set>
-
-    <!-- =========================================================== -->
-    <!-- Configure Request Log                                       -->
-    <!-- Request logs  may be configured for the entire server here, -->
-    <!-- or they can be configured for a specific web app in a       -->
-    <!-- contexts configuration (see $(jetty.home)/contexts/test.xml -->
-    <!-- for an example).                                            -->
-    <!-- =========================================================== -->
-    <Ref id="RequestLog">
-      <Set name="requestLog">
-        <New id="RequestLogImpl" class="org.mortbay.jetty.NCSARequestLog">
-          <Arg><SystemProperty name="jetty.logs" default="./logs"/>/yyyy_mm_dd.request.log</Arg>
-          <Set name="retainDays">90</Set>
-          <Set name="append">true</Set>
-          <Set name="extended">false</Set>
-          <Set name="LogTimeZone">GMT</Set>
-        </New>
-      </Set>
-    </Ref>
 
     <!-- =========================================================== -->
     <!-- extra options                                               -->


### PR DESCRIPTION
Original patch from schisamo:

This log is not needed as the opscode-solr logs will tell us if
something goes wrong with it's container, which is Jetty.
