### PR TITLE
Update Gemfile.lock so latest omnnibus-software is pulled in

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: f37700aaa3752d98d2e3d38cb6704bd850efc8ba
+  revision: 5ee2eae4a159f3c20dccf89e64a3532eadba2eff
   branch: master
   specs:
     omnibus-software (0.0.1)
@@ -11,14 +11,14 @@ GEM
     addressable (2.3.5)
     arr-pm (0.0.8)
       cabin (> 0)
-    backports (3.3.5)
+    backports (3.5.0)
     cabin (0.6.1)
-    childprocess (0.3.9)
+    childprocess (0.4.0)
       ffi (~> 1.0, >= 1.0.11)
     clamp (0.6.3)
     ffi (1.9.3)
     ffi (1.9.3-x86-mingw32)
-    fpm (1.0.0)
+    fpm (1.0.2)
       arr-pm (~> 0.0.8)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
@@ -27,7 +27,7 @@ GEM
       ffi
       ftw (~> 0.0.30)
       json (>= 1.7.7)
-    ftw (0.0.37)
+    ftw (0.0.39)
       addressable
       backports (>= 2.6.2)
       cabin (> 0)
@@ -60,7 +60,7 @@ GEM
       rake (>= 0.9)
       thor (>= 0.16.0)
       uber-s3
-    rake (10.1.0)
+    rake (10.1.1)
     systemu (2.5.2)
     thor (0.18.1)
     uber-s3 (0.2.4)
@@ -73,8 +73,7 @@ GEM
     windows-pr (1.2.2)
       win32-api (>= 1.4.5)
       windows-api (>= 0.3.0)
-    yajl-ruby (1.1.0)
-    yajl-ruby (1.1.0-x86-mingw32)
+    yajl-ruby (1.2.0)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
This pulls in the latest cert changes to the software can build without
needing to use the cached versions

This was done on a branch off the hh/sqitch-upgrade branch. It can be merged into @hosh's branch and when that is merged down go into master.
