### PR TITLE
Update sqerl config to use db_driver_mod

### DIFF
--- a/files/chef-server-cookbooks/chef-server/templates/default/erchef.config.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/erchef.config.erb
@@ -95,6 +95,7 @@
            {db_user, "<%= node['chef_server']['postgresql']['sql_user'] %>"},
            {db_pass, "<%= node['chef_server']['postgresql']['sql_password'] %>"},
            {db_name, "opscode_chef" },
+           {idle_check, 10000},
 
            {prepared_statements, {chef_sql, statements, []}},
            {column_transforms,


### PR DESCRIPTION
The old setting was deprecated and throwing warnings on erchef start,
but erchef was just using the default (and only option) of postgres,
so everything was still working.
