### PR TITLE
Bump chef-pedant version to 1.0.24

### DIFF
--- a/config/software/chef-pedant.rb
+++ b/config/software/chef-pedant.rb
@@ -17,7 +17,7 @@
 
 name "chef-pedant"
 
-version "1.0.20"
+version "1.0.24"
 
 dependency "ruby"
 dependency "bundler"


### PR DESCRIPTION
Not much else to say, except pull in the latest version of chef-pedant into omnibus-chef-server
