### PR TITLE
Allow setting the nginx log_dir via attribute

### DIFF
--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx.conf.erb
@@ -1,6 +1,6 @@
 user <%= node['chef_server']['user']['username'] %> <%= node['chef_server']['user']['username']%>;
 worker_processes <%= @worker_processes %>;
-error_log /var/log/chef-server/nginx/error.log<%= node['chef_server']['lb']['debug'] ? " debug" : "" %>;
+error_log <%= node['chef_server']['nginx']['log_directory'] %>/error.log<%= node['chef_server']['lb']['debug'] ? " debug" : "" %>;
 
 daemon off;
 
@@ -51,7 +51,7 @@ http {
 
   server {
     listen <%= @non_ssl_port %>;
-    access_log /var/log/chef-server/nginx/rewrite-port-<%= @non_ssl_port %>.log;
+    access_log <%= node['chef_server']['nginx']['log_directory'] %>/rewrite-port-<%= @non_ssl_port %>.log;
     return 301 https://$host:<%= @ssl_port %>$request_uri;
   }
   <%- end -%>

--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx_chef_api_lb.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx_chef_api_lb.conf.erb
@@ -1,7 +1,7 @@
 server {
   listen <%= @server_port %>;
   server_name <%= @server_name %>;
-  access_log /var/log/chef-server/nginx/access.log opscode;
+  access_log <%= node['chef_server']['nginx']['log_directory'] %>/access.log opscode;
 
   <% if @server_proto == "https" -%>
   ssl on;


### PR DESCRIPTION
Previously setting this attribute would cause nginx to fail to start
since the log dir referenced in these files would never get created
