### PR TITLE
Add a file to track MVPs

### DIFF
--- a/SERVER_MVPS.md
+++ b/SERVER_MVPS.md
@@ -1,0 +1,18 @@
+### Chef is proud of our community!
+
+Every release of Chef and Ohai we pick someone from the community to name as the Most Valuable Player for that release. It could be someone who provided a big feature, reported a security vulnerability, or someone doing great things in the community that we want to highlight.
+
+#### Hall of Fame
+
+After receiving three MVP awards from a release, we add someone to the hall of fame. We want to express our gratitude to their continuing participation and give newer community members the opportunity to be reconignized.
+
+The [MVP list](https://github.com/opscode/chef/blob/master/CHEF_MVPS.md) is kept in the Chef project.
+
+#### Server Release MVP Recipients
+
+| Release | Date | MVP |
+|---------|------|-----|
+| [Server 11.0.8](http://www.opscode.com/blog/2013/04/23/chef-server-11-0-8-released/) | 2013-04-23 | Joe Breu |
+| [Server 11.0.6](http://www.opscode.com/blog/2013/02/15/chef-server-11-0-6-and-10-24-0-released/) | 2013-02-15 | Michael Della Bitta |
+| [Server 11.0.0](http://www.opscode.com/blog/2013/02/04/chef-11-released/) | 2013-02-04 | Andrea Campi, Bryan Berry |
+


### PR DESCRIPTION
We're taking MVPs off the wiki and putting them in the individual projects.
We've been a little lackluster lately about picking MVPs for server releases.
If we're not going to continue we should fine a place to memorialize those that
we have already recognized.
