### PR TITLE
Update platform_map with new build matrix label names

### DIFF
--- a/jenkins/chef-server.json
+++ b/jenkins/chef-server.json
@@ -1,19 +1,19 @@
 {
-    "build_os=centos-5.5,machine_architecture=x86_64,project=chef-server,role=builder": [
+    "platform=centos-5.5,architecture=x86_64,project=chef-server,role=builder": [
         [
             "el",
             "5",
             "x86_64"
         ]
     ],
-    "build_os=centos-6.2,machine_architecture=x86_64,project=chef-server,role=builder": [
+    "platform=centos-6.2,architecture=x86_64,project=chef-server,role=builder": [
         [
             "el",
             "6",
             "x86_64"
         ]
     ],
-    "build_os=ubuntu-10.04,machine_architecture=x86_64,project=chef-server,role=builder": [
+    "platform=ubuntu-10.04,architecture=x86_64,project=chef-server,role=builder": [
         [
             "ubuntu",
             "10.04",
@@ -25,7 +25,7 @@
             "x86_64"
         ]
     ],
-    "build_os=ubuntu-11.04,machine_architecture=x86_64,project=chef-server,role=builder": [
+    "platform=ubuntu-11.04,architecture=x86_64,project=chef-server,role=builder": [
         [
             "ubuntu",
             "11.04",
@@ -37,7 +37,7 @@
             "x86_64"
         ]
     ],
-    "build_os=ubuntu-12.04,machine_architecture=x86_64,project=chef-server,role=builder": [
+    "platform=ubuntu-12.04,architecture=x86_64,project=chef-server,role=builder": [
         [
             "ubuntu",
             "12.04",


### PR DESCRIPTION
We recently updated the following matrix labels for the Jenkins build 
matrix:

build_os -> platform
machine_architecture -> architecture

OSC's release script relies on the values in this JSON file to map a 
directory to a certain platform, platform value and architecture.

pipeline test here:
http://andra.ci.opscode.us/job/chef-server-trigger-ad_hoc/5/downstreambuildview/

/cc @mmzyk 
