### PR TITLE
order labels alphabetically in platform map key naming

### DIFF
--- a/jenkins/chef-server.json
+++ b/jenkins/chef-server.json
@@ -1,19 +1,19 @@
 {
-    "platform=centos-5.5,architecture=x86_64,project=chef-server,role=builder": [
+    "architecture=x86_64,platform=centos-5.5,project=chef-server,role=builder": [
         [
             "el",
             "5",
             "x86_64"
         ]
     ],
-    "platform=centos-6.2,architecture=x86_64,project=chef-server,role=builder": [
+    "architecture=x86_64,platform=centos-6.2,project=chef-server,role=builder": [
         [
             "el",
             "6",
             "x86_64"
         ]
     ],
-    "platform=ubuntu-10.04,architecture=x86_64,project=chef-server,role=builder": [
+    "architecture=x86_64,platform=ubuntu-10.04,project=chef-server,role=builder": [
         [
             "ubuntu",
             "10.04",
@@ -25,7 +25,7 @@
             "x86_64"
         ]
     ],
-    "platform=ubuntu-11.04,architecture=x86_64,project=chef-server,role=builder": [
+    "architecture=x86_64,platform=ubuntu-11.04,project=chef-server,role=builder": [
         [
             "ubuntu",
             "11.04",
@@ -37,7 +37,7 @@
             "x86_64"
         ]
     ],
-    "platform=ubuntu-12.04,architecture=x86_64,project=chef-server,role=builder": [
+    "architecture=x86_64,platform=ubuntu-12.04,project=chef-server,role=builder": [
         [
             "ubuntu",
             "12.04",


### PR DESCRIPTION
This change builds on d8ba1dffb60e61386dbc326f402da318b1d9d3ca which was merged prematurely. Jenkins creates directory names based on alphabetical order of a build matrix's label when copying artifacts from another project.

/cc @mmzyk 

I'll merge this change once I've verified things in my local dev cluter.
