### PR TITLE
Properly declare the release script's deps

### DIFF
--- a/jenkins/Gemfile
+++ b/jenkins/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'mixlib-shellout', '~> 1.3'

--- a/jenkins/Gemfile.lock
+++ b/jenkins/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mixlib-shellout (1.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  mixlib-shellout (~> 1.3)


### PR DESCRIPTION
Previously we made the assumption that `mixlib-shellout` is installed 
on any machine that would execute the release script.

This change requires https://github.com/opscode-cookbooks/opscode-ci/pull/104 being deployed first.

/cc @opscode/release-engineers @mmzyk 
