### PR TITLE
Update gems to pull in latest omnibus-sofware to fix Heartbleed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/opscode/omnibus-software.git
-  revision: 32e32984bbd180375f0418fee6da1a991227b1fa
+  revision: ff864b6b046107972f57c3b4855915ae5c99f6fd
   specs:
     omnibus-software (0.0.1)
 
@@ -39,11 +39,11 @@ GEM
     mixlib-cli (1.4.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.3.0)
-    mixlib-shellout (1.3.0-x86-mingw32)
+    mixlib-shellout (1.4.0)
+    mixlib-shellout (1.4.0-x86-mingw32)
       win32-process (~> 0.7.1)
       windows-pr (~> 1.2.2)
-    ohai (6.20.0)
+    ohai (6.22.0)
       ipaddress
       mixlib-cli
       mixlib-config


### PR DESCRIPTION
In addition to updating omnibus-software, also updated
  mixlib-shellout to 1.4.0 from 1.3.0
  ohai to 6.22.0 to 6.20.0

Only question is how the mixlib-shellout affects things. I assume it is okay, but will run a build to test.
