### PR TITLE
remove obsoletes reference.

### DIFF
--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -19,7 +19,6 @@ name "chef-server"
 maintainer "Opscode, Inc."
 homepage "http://www.opscode.com"
 
-replaces        "chef-server"
 install_path    "/opt/chef-server"
 build_version   Omnibus::BuildVersion.new.semver
 build_iteration 1


### PR DESCRIPTION
this is bad copypasta from the chef project.  the chef project
needs to replace "chef-full" which used to be the name of the
artifact that was produced a long time ago and we changed the
name (so it has replaces "chef-full").  the chef-server artifact has always
been named "chef-server", so it never needed a "replaces" line in 
the project at all.

this fixes errors in yum like:

"Cannot install package chef-server-11.0.12-1.el6.x86_64. It is
obsoleted by installed package chef-server-11.0.10-1.el6.x86_64"

this cannot fix existing broken installations that have obsoletes
so users should probably use this for now (which uses rpm, not
yum to do the install):

curl -L https://www.opscode.com/chef/install.sh | bash -s -- -P server
