### PR TITLE
Remove port from erchef webui config

### DIFF
--- a/files/chef-server-cookbooks/chef-server/recipes/chef-server-webui.rb
+++ b/files/chef-server-cookbooks/chef-server/recipes/chef-server-webui.rb
@@ -42,16 +42,13 @@ session_store_config = File.join(chef_server_webui_etc_dir, "session_store.rb")
 secret_token_config = File.join(chef_server_webui_etc_dir, "secret_token.rb")
 config_ru = File.join(chef_server_webui_etc_dir, "config.ru")
 
-erchef_url = "http://#{node['chef_server']['erchef']['listen']}"
-erchef_url << ":#{node['chef_server']['erchef']['port']}"
-
 template env_config do
   source "chef-server-webui-config.rb.erb"
   owner "root"
   group "root"
   mode "0644"
   variables({
-    :chef_server_url => erchef_url
+    :chef_server_url => node['chef_server']['nginx']['url'],
   }.merge(node['chef_server']['chef-server-webui'].to_hash))
   notifies :restart, 'service[chef-server-webui]' if should_notify
 end


### PR DESCRIPTION
With the port set the webui is for some reason unable to find
erchef when doing cookbook lookups. Removing the port seems to fix this.
