### PR TITLE
fix debian runit init script type

### DIFF
--- a/files/chef-server-cookbooks/runit/recipes/default.rb
+++ b/files/chef-server-cookbooks/runit/recipes/default.rb
@@ -19,7 +19,12 @@
 
 case node["platform_family"]
 when "debian"
-  include_recipe "runit::upstart"
+  case node["platform"]
+  when "debian"
+    include_recipe "runit::sysvinit"
+  else # this catches ubuntu and any random ubuntu-derived debian-ish distros
+    include_recipe "runit::upstart"
+  end
 when "rhel"
   case node["platform"]
   when "amazon", "xenserver"


### PR DESCRIPTION
previously debian fell through by accident to the sysvinit
method, which broke when we started assigning all of the "debian"
platform_family to be upstart.

since most derived-distros that i'm aware that ohai detects are
descendents of ubuntu rather than debian i structured the case
statement to fall through by default to ubuntu-like behavior.
