### PR TITLE
`initctl stop chef-server-runsvdir` leaves orphaned processes

### DIFF
--- a/files/chef-server-cookbooks/runit/files/default/chef-server-runsvdir.conf
+++ b/files/chef-server-cookbooks/runit/files/default/chef-server-runsvdir.conf
@@ -1,6 +1,12 @@
 start on runlevel [2345]
 stop on shutdown
 respawn
+pre-stop script
+   # To avoid Chef service processes from being orphaned,
+   # we need to ensure everything is stopped before we kill our
+   # runsvdir process.
+   /usr/bin/chef-server-ctl stop
+end script
 post-stop script
    # To avoid stomping on runsv's owned by a different runsvdir
    # process, kill any runsv process that has been orphaned, and is


### PR DESCRIPTION
The right thing to do would be to have 'kill signal HUP' in
the Upstart config so everything gets taken care of cleanly
when you use upstart to stop the runsvdir process. But that
stanza isn't available in Ubuntu 10.04. Without that stanza
Upstart sends a TERM which kills runsvdir and orphans all the
rest of its process tree.

This fix does the same thing Enterprise Chef server does. It
stops Chef services in a pre-stop script.
