### PR TITLE
Updated 2.0-stable omnibus with downgraded FPM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'omnibus', '~> 2.0.1'
+gem 'omnibus', github: 'opscode/omnibus-ruby', branch: '2.0-stable'
 gem 'omnibus-software', github: 'opscode/omnibus-software'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,18 @@
 GIT
+  remote: git://github.com/opscode/omnibus-ruby.git
+  revision: 0ba833567fd2e80215d99fd54d2b9d741c4a37fd
+  branch: 2.0-stable
+  specs:
+    omnibus (2.0.1)
+      fpm (~> 0.4)
+      mixlib-config (~> 2.1)
+      mixlib-shellout (~> 1.3)
+      ohai (~> 6.12)
+      rake
+      thor (>= 0.16.0)
+      uber-s3
+
+GIT
   remote: git://github.com/opscode/omnibus-software.git
   revision: a08918d84cb4ae31d4c749167def662350aa6235
   specs:
@@ -17,13 +31,12 @@ GEM
     clamp (0.6.3)
     ffi (1.9.3)
     ffi (1.9.3-x86-mingw32)
-    fpm (1.0.2)
+    fpm (0.4.42)
       arr-pm (~> 0.0.8)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
       childprocess
       clamp (~> 0.6)
-      ffi
       ftw (~> 0.0.30)
       json (>= 1.7.7)
     ftw (0.0.39)
@@ -36,7 +49,7 @@ GEM
     ipaddress (0.8.0)
     json (1.8.1)
     mime-types (1.25.1)
-    mixlib-cli (1.4.0)
+    mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
     mixlib-shellout (1.4.0)
@@ -51,15 +64,7 @@ GEM
       mixlib-shellout
       systemu (~> 2.5.2)
       yajl-ruby
-    omnibus (2.0.1)
-      fpm (~> 1.0.0)
-      mixlib-config (~> 2.1)
-      mixlib-shellout (~> 1.3)
-      ohai (~> 6.12)
-      rake
-      thor (>= 0.16.0)
-      uber-s3
-    rake (10.3.1)
+    rake (10.3.2)
     systemu (2.5.2)
     thor (0.19.1)
     uber-s3 (0.2.4)
@@ -72,12 +77,12 @@ GEM
     windows-pr (1.2.3)
       win32-api (>= 1.4.5)
       windows-api (>= 0.4.0)
-    yajl-ruby (1.2.0)
+    yajl-ruby (1.2.1)
 
 PLATFORMS
   ruby
   x86-mingw32
 
 DEPENDENCIES
-  omnibus (~> 2.0.1)
+  omnibus!
   omnibus-software!


### PR DESCRIPTION
FPM 1.0.0+ uses FFI to attach to some `libc` functions. This logic is
completely broken on RHEL 5 & 6. As we don’t need a bleeding edge FPM
the easiest fix is to just downgrade to the most recent pre-1.0.0
version.

This change has been tested in CI:
http://wilson.ci.opscode.us/job/chef-server-trigger-ad_hoc/1/downstreambuildview/

/cc @opscode/server-team @opscode/release-engineers 
