### PR TITLE
Bump webui to 11.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Chef Server Changelog
 
+## 11.1.4 Unreleased
+
+### [chef-server-webui 11.1.3](https://github.com/opscode/chef-server-webui/releases/tag/11.1.3)
+[CHEF-4859](https://tickets.opscode.com/browse/CHEF-4859) Support rendering non-ascii characters in cookbook files
+
+
 ## 11.1.3 (2014-06-26)
 
 ### chef-server-cookbooks

--- a/config/software/chef-server-webui.rb
+++ b/config/software/chef-server-webui.rb
@@ -16,7 +16,7 @@
 #
 
 name "chef-server-webui"
-default_version "11.1.2"
+default_version "11.1.3"
 
 dependency "ruby"
 dependency "bundler"


### PR DESCRIPTION
Pretty simple, as the title indicates. Pulling in a few fixes so we can do a release of the chef server to clean up some loose ends.
