### PR TITLE
Set correct maintainer and homepage.

### DIFF
--- a/config/projects/chef-server-core.rb
+++ b/config/projects/chef-server-core.rb
@@ -16,8 +16,8 @@
 #
 
 name "chef-server-core"
-maintainer "Opscode, Inc."
-homepage "http://www.opscode.com"
+maintainer "Chef Software, Inc."
+homepage   "http://www.getchef.com"
 
 replaces        "chef-server-core"
 install_path    "/opt/chef-server"

--- a/config/projects/chef-server.rb
+++ b/config/projects/chef-server.rb
@@ -16,8 +16,8 @@
 #
 
 name "chef-server"
-maintainer "Opscode, Inc."
-homepage "http://www.opscode.com"
+maintainer "Chef Software, Inc."
+homepage   "http://www.getchef.com"
 
 install_path    "/opt/chef-server"
 build_version   Omnibus::BuildVersion.new.semver


### PR DESCRIPTION
This data is important when publishing to Artifactory as it’s used in 
the underlying package path in the repo (e.g. `com/getchef`).

/cc @opscode/release-engineers @opscode/server-team 

We'll probably need to backport this change to all stable branches also.
