### PR TITLE
Attribute for depsolver_timeout not used anywhere

### DIFF
--- a/files/chef-server-cookbooks/chef-server/attributes/default.rb
+++ b/files/chef-server-cookbooks/chef-server/attributes/default.rb
@@ -139,7 +139,7 @@ default['chef_server']['erchef']['umask'] = "0022"
 default['chef_server']['erchef']['web_ui_client_name'] = "chef-webui"
 default['chef_server']['erchef']['root_metric_key'] = "chefAPI"
 default['chef_server']['erchef']['depsolver_worker_count'] = 5
-default['chef_server']['erchef']['depsolver_timeout'] = 5000
+default['chef_server']['erchef']['depsolver_timeout'] = 2000
 default['chef_server']['erchef']['max_request_size'] = 1000000
 
 ####

--- a/files/chef-server-cookbooks/chef-server/templates/default/erchef.config.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/erchef.config.erb
@@ -114,7 +114,8 @@
                   {s3_external_url, <%= @helper.erl_atom_or_string(node['chef_server']['bookshelf']['external_url']) %>},
                   {s3_url_ttl, <%= @s3_url_ttl %>},
                   {s3_parallel_ops_timeout, <%= @s3_parallel_ops_timeout %>},
-                  {s3_parallel_ops_fanout, <%= @s3_parallel_ops_fanout %>}
+                  {s3_parallel_ops_fanout, <%= @s3_parallel_ops_fanout %>},
+                  {depsolver_timeout, <%= @depsolver_timeout %>}
                  ]},
   {stats_hero, [
                {udp_socket_pool_size, 1 },


### PR DESCRIPTION
The chef-server attributes includes `despsolver_timeout` but that value wasn't applied anywhere. Changed that value to match the
hard-coded value, 2000, at

https://github.com/opscode/chef_objects/blob/master/src/chef_depsolver.erl#L46

and updated erchef.config to use that value per

 https://github.com/opscode/chef_objects/blob/master/src/chef_depsolver.erl#L127
