### PR TITLE
Set headers to prevent caching in webui

### DIFF
--- a/files/chef-server-cookbooks/chef-server/templates/default/nginx_chef_api_lb.conf.erb
+++ b/files/chef-server-cookbooks/chef-server/templates/default/nginx_chef_api_lb.conf.erb
@@ -84,6 +84,8 @@ server {
     set $my_upstream erchef;
     if ($http_x_ops_userid = "") {
       set $my_upstream chef_server_webui;
+      add_header Pragma "no-cache";
+      add_header Cache-Control "no-store, no-cache, must-revalidate, post-check=0, pre-check=0, max-age=0, s-maxage=0, private";
     }
     proxy_redirect http://$my_upstream /;
     proxy_pass http://$my_upstream;


### PR DESCRIPTION
Fixes opscode/chef#1757.
- OWASP reference: https://www.owasp.org/index.php/Testing_for_Browser_cache_weakness_(OTG-AUTHN-006)
- HTTP RFC describing these fields: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9

Note that the response may have multiple `Cache-Control` headers, but that's OK according to the spec and their values are merged when being interpreted by the client.
